### PR TITLE
Remove documentation of the abandoned transformation rule for disjointness

### DIFF
--- a/modules/ROOT/pages/transformation/transf-rules2.adoc
+++ b/modules/ROOT/pages/transformation/transf-rules2.adoc
@@ -22,7 +22,6 @@ In this section are specified transformation rules for UML association, generali
 |Property generalisation |<<rule:generalisation-property-core>> | |
 |Class equivalence | | |<<rule:equivalent-classes-rc>>
 |Property equivalence | | |<<rule:equivalent-properties-rc>>
-|Disjoint classes | | |<<rule:disjoint-classes-rc>>
 |Realisation |<<rule:realisation-class-core>> | |
 |===
 
@@ -552,9 +551,7 @@ Generalisation [xref:references.adoc#ref:uml2.5[uml2.5]] defines specialization 
 [#fig:generalisation-visual]
 image::f13.png[13]
 
-//TODO: Verify this statement. It doesn't make too much sense. Needs reformulation. Plus, it might be irrelevant if we don't make a rule for generating (optional) disjoint classes statements. Adding a sentence about this to refer to an individual rule for generating disjoint statements.
-UML generalisation set [xref:references.adoc#ref:uml2.5[uml2.5]] groups generalisations; incomplete and disjoint constraints indicate that the set is not complete and its specific Classes have no common instances. The UML conventions specify that all sibling classes are by default disjoint, therefore even if no generalisation set is provided it is assumed to be implicit.
-Sibling classes will be declared disjoint with one another in the reasoning layer (see xref:rule:disjoint-classes-rc[]).
+A UML generalisation set [xref:references.adoc#ref:uml2.5[uml2.5]] groups generalisations. Subclasses in a generalization set are, by default, incomplete and can overlap. Generalization set properties are not supported.
 
 [#rule:generalisation-class-core,source,XML,caption='',title='{example-caption} {counter:rule-cnt:2.1}. Class generalisation -- in core ontology layer',reftext='{example-caption} {rule-cnt}']
 ====
@@ -675,39 +672,6 @@ Specify equivalent property axiom for the generalisation with `\<<equivalent>>` 
 </rdf:Description>
 <rdf:Description rdf:about = "http://base.onto.uri/isSisterOf">
   <owl:equivalentProperty rdf:resource = "http://base.onto.uri/isRelatedTo"/>
-</rdf:Description>
-----
-|===
-
-=== Disjoint classes
-
-[#rule:disjoint-classes-rc,source,XML,caption='',title='{example-caption} {counter:rule-cnt:2.1}. Disjoint classes -- in reasoning layer',reftext='{example-caption} {rule-cnt}']
-====
-Specify a disjoint classes axiom for all "sibling" classes, i.e. for multiple UML Classes that have generalisation connectors to the same UML Class.
-====
-
-For the generalisation relations depicted in xref:fig:generalisation-visual[], the generated output should have the following form.
-
-[cols="a,a", options="noheader"]
-|===
-|
-.Disjoint classes declaration in Turtle syntax
-[source,Turtle]
-----
-[ a owl:AllDisjointClasses ;
-  owl:members  ( :ClassName :OtherClass )
-] .
-----
-|
-.Disjoint classes declaration in RDF/XML syntax
-[source,XML]
-----
-<rdf:Description>
-    <rdf:type rdf:resource="http://...owl#AllDisjointClasses"/>
-    <owl:members rdf:parseType="Collection">
-        <rdf:Description rdf:about="http://base.onto.uri/ClassName"/>
-        <rdf:Description rdf:about="http://base.onto.uri/OtherClass"/>
-    </owl:members>
 </rdf:Description>
 ----
 |===

--- a/modules/ROOT/pages/uml/conv-conn-generalization.adoc
+++ b/modules/ROOT/pages/uml/conv-conn-generalization.adoc
@@ -72,24 +72,6 @@ For classes defined in external models proxy uml:Class elements should be define
 In case a model class should inherit a class from an external model then proxies must be created for those classes. For example, if `Buyer` specialises an `org:Organization`, then a proxy for `org:Organization` must be created in the `org` package.
 
 
-[[rule:generalization-disjoint-subclasses]]
-|===
-|{set:cellbgcolor: #a8c6f7}
- *Title:* Disjoint subclasses
-
-|{set:cellbgcolor: #f5f8fc}
-*Identifier:* rule:generalization-disjoint-subclasses
-
-|*Statement:*
-Subclasses of the same class, represented by multiple uml:Generalization connectors pointing to the same superclass, are assumed disjoint by default. Exceptions may exist and can be encoded.
-|===
-
-*Description:*
-
-In this specification, the subclasses are assumed disjoint by default, unless otherwise specified in the transformations script, or explicitly marked on the generalisation relation with `\<<non-disjoint>>` stereotype. For the converse case the `\<<disjoint>>` stereotype shall be used.
-
-
-
 [[rule:generalization-equivalent-classes]]
 |===
 |{set:cellbgcolor: #a8c6f7}


### PR DESCRIPTION
Documentation of the rule has been removed along with a related convention. Other related part of the documentation has been updated.