### PR TITLE
Introduce JSON-LD context generation

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -19,6 +19,7 @@ The following capabilities are implemented:
 * UML -> OWL 2 (lightweight ontology suitable as a core vocabulary)
 * UML -> OWL 2 (heavyweight ontology with additional axioms suitable for reasoning purposes)
 * UML -> SHACL (data shapes suitable for representing an application profile)
+* UML -> JSON-LD context (an accompanying context file for the ontology, suitable for use in JSON-LD applications)
 * UML -> SVRL (Compliance report in SVRL format)
 
 This documentation is evolving and aims at covering the following aspects related to use of these tools:

--- a/modules/ROOT/pages/transformation/transf-rules1.adoc
+++ b/modules/ROOT/pages/transformation/transf-rules1.adoc
@@ -8,14 +8,14 @@ In this section are specified transformation rules for UML class and attribute e
 
 [[tab:class-attribute-overview]]
 .Overview of transformation rules for UML classes and attributes
-[cols="<,<,<,<",options="header",]
+[cols="<,<,<,<,<",options="header",]
 |===
-|UML element |Rules in core ontology layer |Rules in data shape layer |Rules in reasoning layer
-|Class |<<rule:class-core>> |<<rule:class-ds>> |
-|Abstract class | |<<rule:class-abstract-ds>> |
-|Attribute |<<rule:attribute-core>> |<<rule:attribute-ds>> |<<rule:attribute-rc-domain>>
-|Attribute type | |<<rule:attribute-ds-range>> |<<rule:attribute-rc-range>>
-|Attribute multiplicity | |<<rule:attribute-ds-multiplicity>> |<<rule:attribute-rc-multiplicity>>, <<rule:attribute-rc-multiplicity-one>>
+|UML element |Rules in core ontology layer |Rules in data shape layer |Rules in reasoning layer | Rules in JSON-LD context layer
+|Class |<<rule:class-core>> |<<rule:class-ds>> | | <<rule:class-ldcontext>>
+|Abstract class | |<<rule:class-abstract-ds>> | |
+|Attribute |<<rule:attribute-core>> |<<rule:attribute-ds>> |<<rule:attribute-rc-domain>> | <<rule:attribute-ldcontext>>
+|Attribute type | |<<rule:attribute-ds-range>> |<<rule:attribute-rc-range>> | <<rule:attribute-type-ldcontext>>
+|Attribute multiplicity | |<<rule:attribute-ds-multiplicity>> |<<rule:attribute-rc-multiplicity>>, <<rule:attribute-rc-multiplicity-one>> | <<rule:attribute-container-ldcontext>>
 |===
 
 [[sec:class]]
@@ -101,6 +101,24 @@ shape:ClassName a sh:NodeShape ;
 <sh:NodeShape rdf:about = "http://base.shape.uri/ClassName">
     <sh:targetClass rdf:resource = "http://base.onto.uri/ClassName"/>
 </sh:NodeShape>
+----
+|===
+
+[#rule:class-ldcontext,source,XML,caption='',title='{example-caption} {counter:rule-cnt:1.1}. Class -- in JSON-LD context layer',reftext='{example-caption} {rule-cnt}']
+====
+Specify a term for each UML class by assigning an absolute URI of the class to the class name. Create the term mapping as a top-level entry of the context object.
+====
+
+[NOTE]
+The term mapping key contains the relevant class name. It does not contain a namespace prefix even if one is defined in the model. Namespace prefixes are not used as all classes defined in the model are presumed to be internal, that is belonging to the generated ontology.
+
+[cols="a", options="noheader"]
+|===
+|
+.Class term mapping in JSON-LD syntax
+[source,JSON]
+----
+"ClassName": "http://base.onto.uri/ClassName"
 ----
 |===
 
@@ -373,6 +391,26 @@ shape:ClassName-attributeName a sh:PropertyShape ;
 |===
 
 
+[#rule:attribute-ldcontext,source,XML,caption='',title='{example-caption} {counter:rule-cnt:1.1}. Attribute -- in JSON-LD context layer',reftext='{example-caption} {rule-cnt}']
+====
+For each UML class attribute, specify a datatype property by creating a property URI mapping with an absolute attribute URI in a node object. Set the term definition as a top-level entry of the context object.
+====
+
+[NOTE]
+The term definition key contains the attribute and the relevant class names. It does not contain a namespace prefix even if one is defined in the model. Namespace prefixes are not used as all classes defined in the model are presumed to be internal, that is belonging to the generated ontology.
+
+[cols="a", options="noheader"]
+|===
+|
+.Class attribute term mapping in JSON-LD syntax
+[source,JSON]
+----
+"ClassName.attribute1": {
+  "@id":"http://base.onto.uri/attribute1"
+}
+----
+|===
+
 === Attribute type
 
 [#rule:attribute-rc-range,source,XML,caption='',title='{example-caption} {counter:rule-cnt:1.1}. Attribute type -- in reasoning layer',reftext='{example-caption} {rule-cnt}']
@@ -505,6 +543,25 @@ shape:ClassName-attribute2
 
 ----
 |===
+
+
+[#rule:attribute-type-ldcontext,source,XML,caption='',title='{example-caption} {counter:rule-cnt:1.1}. Class attribute type -- in JSON-LD context layer',reftext='{example-caption} {rule-cnt}']
+====
+For each UML class attribute, specify its range by creating a type coercion entry with an absolute URI of the attribute datatype in a node object. Set the term definition as a top-level entry of the context object.
+====
+
+[cols="a", options="noheader"]
+|===
+|
+.Class attribute type definition in JSON-LD syntax
+[source,JSON]
+----
+"ClassName.attribute1": {
+  "@type":"http://www.w3.org/2001/XMLSchema#string"
+}
+----
+|===
+
 
 [[sec:attribute-multiplicity]]
 === Attribute multiplicity
@@ -777,5 +834,32 @@ shape:ClassName-attribute4
     <sh:maxCount rdf:datatype="http://www.w3.org...#integer"
       >2</sh:maxCount>
 </rdf:Description>
+----
+|===
+
+
+[#rule:attribute-container-ldcontext,source,XML,caption='',title='{example-caption} {counter:rule-cnt:1.1}. Class attribute container -- in JSON-LD context layer',reftext='{example-caption} {rule-cnt}']
+====
+Specify a default container type for a class attribute that can accept more than a one value by setting the fixed `@set` keyword as a value for the `@container` key. Set the container type entry inside a term definition created as a top-level entry of the context object.
+====
+
+[cols="a", options="noheader"]
+|===
+|
+.Attribute container definition in JSON-LD syntax
+[source,JSON]
+----
+"ClassName.attribute1": {
+ "@container": "@set"
+}
+"ClassName.attribute2": {
+ "@container": "@set"
+}
+"ClassName.attribute3": {
+ "@container": "@set"
+}
+"ClassName.attribute4": {
+ "@container": "@set"
+}
 ----
 |===

--- a/modules/ROOT/pages/transformation/transf-rules2.adoc
+++ b/modules/ROOT/pages/transformation/transf-rules2.adoc
@@ -5,25 +5,25 @@ In this section are specified transformation rules for UML association, generali
 
 [[tab:connectors-overview]]
 .Transformation rules overview for UML connectors
-[cols="<,<,<,<",options="header",]
+[cols="<,<,<,<,<",options="header",]
 |===
-|UML element |Rules in core ontology layer |Rules in data shape layer |Rules in reasoning layer
-|Association |<<rule:association-uni-core>> |<<rule:association-uni-ds>> |
-|Association domain | | |<<rule:association-uni-domain-rc>>
-|Association range | |<<rule:association-uni-range-ds>> |<<rule:association-uni-range-rc>>
-|Association multiplicity | |<<rule:association-uni-multiplicity-ds>> |<<rule:association-uni-multiplicity-rc>>, <<rule:association-uni-multiplicity-one-rc>>
-|Association asymmetry | |<<rule:association-uni-asymetry-ds>> |<<rule:association-uni-asymetry-rc>>
-|Association inverse | | |<<rule:association-bi-inverse-rc>>
-|Dependency |<<rule:association-uni-core>> |<<rule:association-uni-ds>> |
-|Dependency domain | | |<<rule:association-uni-domain-rc>>
-|Dependency range | |<<rule:dependency-uni-range-ds>> |<<rule:dependency-uni-range-rc>>
-|Dependency multiplicity | |<<rule:association-uni-multiplicity-ds>> |<<rule:association-uni-multiplicity-rc>>, <<rule:association-uni-multiplicity-one-rc>>
-|Class generalisation |<<rule:generalisation-class-core>> | |
-|Property generalisation |<<rule:generalisation-property-core>> | |
-|Class equivalence | | |<<rule:equivalent-classes-rc>>
-|Property equivalence | | |<<rule:equivalent-properties-rc>>
-|Disjoint classes | | |<<rule:disjoint-classes-rc>>
-|Realisation |<<rule:realisation-class-core>> | |
+|UML element |Rules in core ontology layer |Rules in data shape layer |Rules in reasoning layer | Rules in JSON-LD context layer
+|Association |<<rule:association-uni-core>> |<<rule:association-uni-ds>> | | <<rule:assoc-dep-ldcontext>>
+|Association domain | | |<<rule:association-uni-domain-rc>> |
+|Association range | |<<rule:association-uni-range-ds>> |<<rule:association-uni-range-rc>> | <<rule:assoc-dep-range-ldcontext>>
+|Association multiplicity | |<<rule:association-uni-multiplicity-ds>> |<<rule:association-uni-multiplicity-rc>>, <<rule:association-uni-multiplicity-one-rc>> | <<rule:assoc-dep-container-ldcontext>>
+|Association asymmetry | |<<rule:association-uni-asymetry-ds>> |<<rule:association-uni-asymetry-rc>> |
+|Association inverse | | |<<rule:association-bi-inverse-rc>> |
+|Dependency |<<rule:association-uni-core>> |<<rule:association-uni-ds>> | | <<rule:assoc-dep-ldcontext>>
+|Dependency domain | | |<<rule:association-uni-domain-rc>> |
+|Dependency range | |<<rule:dependency-uni-range-ds>> |<<rule:dependency-uni-range-rc>> | <<rule:assoc-dep-range-ldcontext>>
+|Dependency multiplicity | |<<rule:association-uni-multiplicity-ds>> |<<rule:association-uni-multiplicity-rc>>, <<rule:association-uni-multiplicity-one-rc>> | <<rule:assoc-dep-container-ldcontext>>
+|Class generalisation |<<rule:generalisation-class-core>> | | |
+|Property generalisation |<<rule:generalisation-property-core>> | | |
+|Class equivalence | | |<<rule:equivalent-classes-rc>> |
+|Property equivalence | | |<<rule:equivalent-properties-rc>> |
+|Disjoint classes | | |<<rule:disjoint-classes-rc>> |
+|Realisation |<<rule:realisation-class-core>> | | |
 |===
 
 [[sec:association-uni]]
@@ -104,6 +104,27 @@ shape:ClassName-relationName a sh:PropertyShape ;
 ----
 |===
 
+
+[#rule:assoc-dep-ldcontext,source,XML,caption='',title='{example-caption} {counter:rule-cnt:1.1}. Association & dependency -- in JSON-LD context layer',reftext='{example-caption} {rule-cnt}']
+====
+For each UML association/dependency, specify an object property by creating a property URI mapping with an absolute URI of a target end in a node object. Set the term definition as a top-level entry of the context object. For bidirectional connectors, additionally specify an extended term definition for the source end.
+====
+
+
+[cols="a", options="noheader"]
+|===
+|
+.Association/dependency term mapping in JSON-LD syntax
+[source,JSON]
+----
+"ClassName.relatesTo": {
+ "@id":"http://base.onto.uri/relatesTo"
+}
+"ClassName.dependencyName": {
+ "@id":"http://base.onto.uri/dependencyName"
+}
+----
+|===
 
 === Association source
 
@@ -250,6 +271,28 @@ shape:ClassName-relationName
 ----
 |===
 
+
+[#rule:assoc-dep-range-ldcontext,source,XML,caption='',title='{example-caption} {counter:rule-cnt:1.1}. Association & dependency range -- in JSON-LD context layer',reftext='{example-caption} {rule-cnt}']
+====
+For each UML association/dependency, specify the object property range by creating a type coercion entry in a node object. Set the fixed `@id` keyword as a value to indicate that that the value of the term should be interpreted as an URI. Set the term definition as a top-level entry of the context object. For bidirectional connectors, additionally specify the object property range for the source end.
+====
+
+[cols="a", options="noheader"]
+|===
+|
+.Type coercion for association & dependency in JSON-LD syntax
+[source,JSON]
+----
+"ClassName.relatesTo": {
+  "@type": "@id"
+}
+"ClassName.dependencyName": {
+  "@type": "@id"
+}
+----
+|===
+
+
 === Association multiplicity
 
 
@@ -337,6 +380,29 @@ shape:ClassName-relationName
 </rdf:Description>
 ----
 |===
+
+
+[#rule:assoc-dep-container-ldcontext,source,XML,caption='',title='{example-caption} {counter:rule-cnt:1.1}. Association & dependency container -- in JSON-LD context layer',reftext='{example-caption} {rule-cnt}']
+====
+Specify a default container type for each UML association/dependency that can accept more than a one value, setting the fixed `@set` keyword as a value for the `@container` key.
+Set the container type entry for an association/dependency target end, inside a term definition created as a top-level entry of the context object. For bidirectional connectors, additionally specify the container type for the source end.
+====
+
+[cols="a", options="noheader"]
+|===
+|
+.Association & dependency container definition in JSON-LD syntax
+[source,JSON]
+----
+"ClassName.relatesTo": {
+ "@container": "@set"
+}
+"ClassName.dependencyName": {
+ "@container": "@set"
+}
+----
+|===
+
 
 [[sec:association-self]]
 === Recursive association

--- a/modules/ROOT/pages/transformation/transf-rules3.adoc
+++ b/modules/ROOT/pages/transformation/transf-rules3.adoc
@@ -5,13 +5,13 @@ In this section are specified transformation rules for UML datatypes and enumera
 
 [[tab:datatype-overview]]
 .Overview of transformation rules for UML datatypes
-[cols="<,<,<,<",options="header",]
+[cols="<,<,<,<,<",options="header",]
 |===
-|UML element |Rules in core ontology layer |Rules in data shape layer |Rules in reasoning layer
-|Primitive datatype |<<rule:datatype-core>> | |
-|Structured datatype |<<rule:datatype-structured-core>> | |
-|Enumeration |<<rule:enumeration-core>> | |<<rule:enumeration-rc>>
-|Enumeration item |<<rule:enumeration-item-core>> | <<rule:enumeration-item-ds>> |
+|UML element |Rules in core ontology layer |Rules in data shape layer |Rules in reasoning layer | Rules in JSON-LD context layer
+|Primitive datatype |<<rule:datatype-core>> | | | <<rule:datatype-ldcontext>>
+|Structured datatype |<<rule:datatype-structured-core>> | | |
+|Enumeration |<<rule:enumeration-core>> | |<<rule:enumeration-rc>> | <<rule:enum-ldcontext>>
+|Enumeration item |<<rule:enumeration-item-core>> | <<rule:enumeration-item-ds>> | |
 |===
 
 [[sec:primitive-type]]
@@ -103,6 +103,23 @@ xsd:boolean a rdfs:Datatype .
 </rdfs:Datatype>
 ----
 |===
+
+
+[#rule:datatype-ldcontext,source,XML,caption='',title='{example-caption} {counter:rule-cnt:1.1}. Datatype -- in JSON-LD context layer',reftext='{example-caption} {rule-cnt}']
+====
+Specify a term for each UML datatype by assigning an absolute URI of the datatype to its name. Create the term mapping as a top-level entry of the context object.
+====
+
+[cols="a", options="noheader"]
+|===
+|
+.Datatype term mapping in JSON-LD syntax
+[source,JSON]
+----
+"rdf:PlainLiteral": "http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral"
+----
+|===
+
 
 === Structured datatypes
 
@@ -283,4 +300,20 @@ shape:EnumName-itemShape a sh:NodeShape ;
 </rdf:Description>
 ----
 
+|===
+
+
+[#rule:enum-ldcontext,source,XML,caption='',title='{example-caption} {counter:rule-cnt:1.1}. Enumeration -- in JSON-LD context layer',reftext='{example-caption} {rule-cnt}']
+====
+Specify a term for each UML enumeration by assigning an absolute URI of the enumeration to its name. Create the term mapping as a top-level entry of the context object.
+====
+
+[cols="a", options="noheader"]
+|===
+|
+.Enumeration term mapping in JSON-LD syntax
+[source,JSON]
+----
+"at-voc:applicability": "http://publications.europa.eu/resource/authority/applicability"
+----
 |===

--- a/modules/ROOT/pages/user-guide/configuration-file.adoc
+++ b/modules/ROOT/pages/user-guide/configuration-file.adoc
@@ -157,7 +157,7 @@ Additionally, a dedicated prefix list ensures that **certain concepts are always
 internal**, preventing them from being excluded even if they would otherwise be classified as
 "reused."
 
-With these parameters (`generateReusedConceptsSHACL`, `generateReusedConceptsOWLcore`, `generateReusedConceptsOWLrestrictions`,
+With these parameters (`generateReusedConceptsSHACL`, `generateReusedConceptsOWLcore`, `generateReusedConceptsOWLrestrictions`, `generateReusedConceptsJSONLDcontext`,
 `generateReusedConceptsGlossary`), **users have full control** over which artefacts generate reused concepts.
 
 Each of these variables acts as a **toggle** for its respective artefact type:
@@ -176,6 +176,7 @@ even if they would sometimes be classified as reused.
 | `generateReusedConceptsSHACL` | Boolean | Enables or disables the inclusion of reused concepts in SHACL artefacts. | `true`
 | `generateReusedConceptsOWLcore` | Boolean | Enables or disables the inclusion of reused concepts in OWL core artefacts. | `true`
 | `generateReusedConceptsOWLrestrictions` | Boolean | Enables or disables the inclusion of reused concepts in OWL restrictions. | `true`
+| `generateReusedConceptsJSONLDcontext` | Boolean | Enables or disables the inclusion of reused concepts in JSON-LD context. | `true`
 | `generateReusedConceptsGlossary` | Boolean | Enables or disables the inclusion of reused concepts in the glossary. | `true`
 |===
 === Status filtering parameters

--- a/modules/ROOT/pages/user-guide/how-to-use.adoc
+++ b/modules/ROOT/pages/user-guide/how-to-use.adoc
@@ -235,7 +235,7 @@ model2owl.
 
 4. `make generate-jsonld-context` – Generates JSON-LD context for JSON-LD applications.
    * Generated File:
-     **`<input-file>_context.jsonld`** – Signatures of ontology terms usable in a JSON-LD data file.
+     **`<input-file>_context.jsonld`** – Signatures of ontology terms usable in a JSON-LD data file. The file consists of a JSON object with a single top-level entry having the `@context` key and an object with link:https://www.w3.org/TR/json-ld/#dfn-term-definition[term definitions] as its value.
 
 5. `make generate-glossary` – Generates an HTML glossary of terms extracted from the UML model.
    * Generated File:

--- a/modules/ROOT/pages/user-guide/how-to-use.adoc
+++ b/modules/ROOT/pages/user-guide/how-to-use.adoc
@@ -69,6 +69,12 @@ These commands execute transformations and generate outputs:
     - `XMI_INPUT_FILE_PATH` – Path to the XMI file.
     - `OUTPUT_FOLDER_PATH` – Path to the output folder.
 
+* `generate-jsonld-context` – Generates JSON-LD context file for the ontology data.
+  ** **Parameters:**
+    - `XMI_INPUT_FILE_PATH` – Path to the XMI file.
+    - `OUTPUT_FOLDER_PATH` – Path to the output folder.
+    - `JSONLD_CONTEXT_INDENTATION` – Indentation for the JSON-LD context file (defaults to 2 spaces).
+
 * `generate-html-docs-from-rdf` – Generates HTML documentation using Widoco from an RDF file.
   ** **Parameters:**
     - `WIDOCO_RDF_INPUT_FILE_PATH` – Path to the RDF file.
@@ -227,15 +233,19 @@ model2owl.
    * Generated File:
      **`<input-file>_shapes.rdf`** – SHACL shapes in RDF format.
 
-4. `make generate-glossary` – Generates an HTML glossary of terms extracted from the UML model.
+4. `make generate-jsonld-context` – Generates JSON-LD context for JSON-LD applications.
+   * Generated File:
+     **`<input-file>_context.jsonld`** – Signatures of ontology terms usable in a JSON-LD data file.
+
+5. `make generate-glossary` – Generates an HTML glossary of terms extracted from the UML model.
    * Generated File:
      **`<input-file>_glossary.html`** – Glossary in HTML format.
 
-5. `make generate-convention-report` – Generates a compliance report from the UML model in HTML format, validating it against the conventions.
+6. `make generate-convention-report` – Generates a compliance report from the UML model in HTML format, validating it against the conventions.
    * Generated File:
      **`<input-file>_convention_report.html`** – HTML compliance report.
 
-6. `make generate-convention-SVRL-report` – Generates a compliance report in SVRL format.
+7. `make generate-convention-SVRL-report` – Generates a compliance report in SVRL format.
    * Generated File:
      **`<input-file>_convention_svrl_report.xml`** – SVRL compliance report.
 


### PR DESCRIPTION
This change introduces transformation rules for the new JSON-LD context file generation feature. It also updates the user manual with a description of a new parameter and CLI command.

Scope of changes:
* Added transformation rules for JSON-LD context generation, supporting UML elements such as classes, enumerations, datatypes, and associations. The rules generate both simple and extended term definitions, including URI mappings, type, and container specifications.
* Updated the configuration documentation to describe the new `generateReusedConceptsJSONLDcontext` parameter.
* Updated the manual to include details about the new `generate-jsonld-context` CLI command.
* Updated the main page.

Index of the new transformation rules:
1. [C.03. Class — in JSON-LD context layer](https://meaningfy-ws.github.io/model2owl-docs-gh-pages/public-review/transformation/transf-rules1.html#rule:class-ldcontext)
1. [C.08. Class attribute — in JSON-LD context layer](https://meaningfy-ws.github.io/model2owl-docs-gh-pages/public-review/transformation/transf-rules1.html#rule:attribute-ldcontext)
1. [C.11. Class attribute type — in JSON-LD context layer](https://meaningfy-ws.github.io/model2owl-docs-gh-pages/public-review/transformation/transf-rules1.html#rule:attribute-type-ldcontext)
1. [C.15. Class attribute container — in JSON-LD context layer](https://meaningfy-ws.github.io/model2owl-docs-gh-pages/public-review/transformation/transf-rules1.html#rule:attribute-container-ldcontext)
1. [R.03. Association and dependency — in JSON-LD context layer](https://meaningfy-ws.github.io/model2owl-docs-gh-pages/public-review/transformation/transf-rules2.html#rule:assoc-dep-ldcontext)
1. [R.07. Association and dependency range — in JSON-LD context layer](https://meaningfy-ws.github.io/model2owl-docs-gh-pages/public-review/transformation/transf-rules2.html#rule:assoc-dep-range-ldcontext)
1. [R.11. Association and dependency container — in JSON-LD context layer](https://meaningfy-ws.github.io/model2owl-docs-gh-pages/public-review/transformation/transf-rules2.html#rule:assoc-dep-container-ldcontext)
1. [D.02 Datatype — in JSON-LD context layer](https://meaningfy-ws.github.io/model2owl-docs-gh-pages/public-review/transformation/transf-rules3.html#rule:datatype-ldcontext)
1. [D.08. Enumeration — in JSON-LD context layer](https://meaningfy-ws.github.io/model2owl-docs-gh-pages/public-review/transformation/transf-rules3.html#rule:enum-ldcontext)

_The published version of the documentation referenced above is available on a staging environment website (build [#32](https://github.com/meaningfy-ws/model2owl-docs-gh-pages/actions/runs/16622071921))._

**This pull request has been superseded by https://github.com/OP-TED/ted-model2owl-docs/pull/19**